### PR TITLE
Detach tribute element $onDestroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ var AngularTribute = function AngularTribute($timeout) {
       onReplaced: '&',
       onNoMatch: '&'
     },
-    controller: function controller($scope) {
+    controller: ['$scope', function ($scope) {
       this.$onDestroy = function () {
         $scope.tribute.hideMenu();
       };
-    },
+    }],
     compile: function compile($element, $attrs) {
       var _this = this;
 
@@ -45,6 +45,10 @@ var AngularTribute = function AngularTribute($timeout) {
         $element[0].addEventListener("tribute-no-match", function (e) {
           if (typeof $scope.onNoMatch !== 'function') return;
           $timeout($scope.onNoMatch.apply(_this));
+        });
+
+        $scope.$on('$destroy', function () {
+          $scope.tribute.detach($element[0]);
         });
       };
     }

--- a/index.umd.js
+++ b/index.umd.js
@@ -19,11 +19,11 @@
         onReplaced: '&',
         onNoMatch: '&'
       },
-      controller: function controller($scope) {
+      controller: ['$scope', function ($scope) {
         this.$onDestroy = function () {
           $scope.tribute.hideMenu();
         };
-      },
+      }],
       compile: function compile($element, $attrs) {
         var _this = this;
 
@@ -47,6 +47,10 @@
           $element[0].addEventListener("tribute-no-match", function (e) {
             if (typeof $scope.onNoMatch !== 'function') return;
             $timeout($scope.onNoMatch.apply(_this));
+          });
+
+          $scope.$on('$destroy', function () {
+            $scope.tribute.detach($element[0]);
           });
         };
       }

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,10 @@ const AngularTribute = ($timeout) => ({
         if (typeof $scope.onNoMatch !== 'function') return;
         $timeout($scope.onNoMatch.apply(this));
       });
+
+      $scope.$on('$destroy', () => {
+        $scope.tribute.detach($element[0]);
+      });
     }
   }
 });


### PR DESCRIPTION
When the tribute directive is destroyed the element is not detached which causes the DOM to become filled with old tribute elements.